### PR TITLE
Use Macro.expand/2 instead of eval

### DIFF
--- a/lib/trans/query_builder.ex
+++ b/lib/trans/query_builder.ex
@@ -80,7 +80,7 @@ if Code.ensure_loaded?(Ecto.Query) do
     """
     defmacro translated(module, translatable, locale) do
       with field <- field(translatable) do
-        module = Module.expand(module, __CALLER__)
+        module = Macro.expand(module, __CALLER__)
         validate_field(module, field)
         generate_query(schema(translatable), module, field, locale)
       end

--- a/lib/trans/query_builder.ex
+++ b/lib/trans/query_builder.ex
@@ -80,10 +80,9 @@ if Code.ensure_loaded?(Ecto.Query) do
     """
     defmacro translated(module, translatable, locale) do
       with field <- field(translatable) do
-        with {module_name, []} <- Module.eval_quoted(__CALLER__, module) do
-          validate_field(module_name, field)
-          generate_query(schema(translatable), module_name, field, locale)
-        end
+        module = Module.expand(module, __CALLER__)
+        validate_field(module, field)
+        generate_query(schema(translatable), module, field, locale)
       end
     end
 


### PR DESCRIPTION
Since the goal is to expand a form (such as an alias) into its value,
we can simply rely on Macro.expand/2 which is simpler and cheaper
than eval.

PS: note I haven't checked if other parts of the codebase could benefit
from similar changes.