### PR TITLE
allow using Trans with embedded_schema

### DIFF
--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -99,6 +99,9 @@ defmodule Trans.Translator do
     Map.fetch(all_translations, to_string(locale))
   end
 
+  # there are no translations for this locale embed
+  defp get_translated_field(nil, _field), do: nil
+
   # check if struct (means it's using ecto embeds); if so, make sure 'field' is also atom
   defp get_translated_field(%{__struct__: _} = translations_for_locale, field)
        when is_binary(field) do

--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -70,15 +70,46 @@ defmodule Trans.Translator do
     # Return the translation or fall back to the default value
     case translated_field(struct, locale, field) do
       :error -> Map.fetch!(struct, field)
+      nil -> Map.fetch!(struct, field)
       translation -> translation
     end
   end
 
   defp translated_field(%{__struct__: module} = struct, locale, field) do
     with {:ok, all_translations} <- Map.fetch(struct, module.__trans__(:container)),
-         {:ok, translations_for_locale} <- Map.fetch(all_translations, to_string(locale)),
-         {:ok, translated_field} <- Map.fetch(translations_for_locale, to_string(field)) do
+         {:ok, translations_for_locale} <- get_translations_for_locale(all_translations, locale),
+         {:ok, translated_field} <- get_translated_field(translations_for_locale, field) do
       translated_field
     end
+  end
+
+  # check if struct (means it's using ecto embeds); if so, make sure 'locale' is also atom
+  defp get_translations_for_locale(%{__struct__: _} = all_translations, locale)
+       when is_binary(locale) do
+    get_translations_for_locale(all_translations, String.to_existing_atom(locale))
+  end
+
+  defp get_translations_for_locale(%{__struct__: _} = all_translations, locale)
+       when is_atom(locale) do
+    Map.fetch(all_translations, locale)
+  end
+
+  # fallback to default behaviour
+  defp get_translations_for_locale(all_translations, locale) do
+    Map.fetch(all_translations, to_string(locale))
+  end
+
+  # check if struct (means it's using ecto embeds); if so, make sure 'field' is also atom
+  defp get_translated_field(%{__struct__: _} = translations_for_locale, field) when is_binary(field) do
+    get_translated_field(translations_for_locale, String.to_existing_atom(field))
+  end
+
+  defp get_translated_field(%{__struct__: _} = translations_for_locale, field) when is_atom(field) do
+    Map.fetch(translations_for_locale, field)
+  end
+
+  # fallback to default behaviour
+  defp get_translated_field(translations_for_locale, field) do
+    Map.fetch(translations_for_locale, to_string(field))
   end
 end

--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -100,11 +100,13 @@ defmodule Trans.Translator do
   end
 
   # check if struct (means it's using ecto embeds); if so, make sure 'field' is also atom
-  defp get_translated_field(%{__struct__: _} = translations_for_locale, field) when is_binary(field) do
+  defp get_translated_field(%{__struct__: _} = translations_for_locale, field)
+       when is_binary(field) do
     get_translated_field(translations_for_locale, String.to_existing_atom(field))
   end
 
-  defp get_translated_field(%{__struct__: _} = translations_for_locale, field) when is_atom(field) do
+  defp get_translated_field(%{__struct__: _} = translations_for_locale, field)
+       when is_atom(field) do
     Map.fetch(translations_for_locale, field)
   end
 


### PR DESCRIPTION
I'm using Trans and I love it :heart: . Recently, I've added a new model to one of my projects and this time I've wanted to approach differently the translation part. I've investigated what it would take to allow Trans to make use of `embedded_schema`. It seems not much. The only change was regarding how to fetch the translations, since all the keys would be atoms now instead of strings in the Ecto loaded struct.

### Why `embedded_schema` ?
* higher flexibility being able to make validations, transformations using the embedded_schema's own changeset
* far easier to work with forms: use `inputs_for` and display by default any changeset errors
* more explicit in how everything works under the hood

All of the above was still possible before, but required some hacking working with nested maps: `model > translations > locale > field`.

### Example

```diff
defmodule Model do
  use Trans, translates: [:name, :slug, :description, :overview]

  schema "models" do
-    field :translations, :map
+    embeds_one :translations, Translations, on_replace: :update
  end

  def changeset(model, attrs) do
    model
-    |> cast(attrs, [:translations])
+    |> cast_embed(:translations)
  end
end
```

```elixir
defmodule Model.Translations do
  use Ecto.Schema
  import Ecto.Changeset

  @primary_key false
  embedded_schema do
    embeds_one :it, Fields, on_replace: :update
    embeds_one :fr, Fields, on_replace: :update
  end

  def changeset(translations, attrs) do
    translations
    |> cast(attrs, [])
    |> cast_embed(:it)
    |> cast_embed(:fr)
  end
end
```
The `embedded_schema` in `Fields` would declare the same fields as in in the `Model` module: `use Trans, translates: [:name, :slug, :description, :overview]`

```elixir
defmodule Model.Translations.Fields do
  use Ecto.Schema
  import Ecto.Changeset

  @primary_key false
  embedded_schema do
    field :name, :string
    field :slug, :string
    field :description, :string
    field :overview, :string
  end

  def changeset(translation_fields, attrs) do
    translation_fields
    |> cast(attrs, [:name, :slug, :description, :overview])
    |> validate_length(:name, min: 10, max: 256)
  end
end
```

```elixir
  # somewhere in the template
  <%= translated_text_field(:it, f, :name) %>

  # some helper
  defp translated_text_field(locale, form, field) when is_atom(locale) do
    inputs_for(form, :translations, fn translations ->
      inputs_for(translations, locale, fn locale ->
        ~E"""
        <%= text_input(locale, field, class: "form-control form-control-lg") %>
        <%= AppWeb.ErrorHelpers.error_tag locale, field %>
        """
      end)
    end)
  end
```

This doesn't bring any breaking changes, but just extends the usage from `:map` to also `embedded_schema`