### PR TITLE
Allow new binary to atom conversion in &translate/3

### DIFF
--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -199,7 +199,7 @@ defmodule Trans.Translator do
   # check if struct (means it's using ecto embeds); if so, make sure 'field' is also atom
   defp get_translated_field(%{__struct__: _} = translations_for_locale, field)
        when is_binary(field) do
-    get_translated_field(translations_for_locale, String.to_existing_atom(field))
+    get_translated_field(translations_for_locale, String.to_atom(field))
   end
 
   defp get_translated_field(%{__struct__: _} = translations_for_locale, field)


### PR DESCRIPTION
With the new usage of `embeds_one` the old behavior of using the function `Trans.Translator.translate(article, :title, "en")` doesn't work if the locale variable isn't already converted to an existing atom.
