### PR TITLE
Translator.translate/2 should fall back to default locale when translation is missing

### DIFF
--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -182,7 +182,7 @@ defmodule Trans.Translator do
     end
   end
 
-  defp translate_fields(%{__struct__: module} = struct, locale, default_locale) do
+  defp translate_fields(%{__struct__: module} = struct, locale, default_locale) when is_list(locale) do
     fields = module.__trans__(:fields)
 
     Enum.reduce(fields, struct, fn field, struct ->
@@ -191,6 +191,10 @@ defmodule Trans.Translator do
         translation -> Map.put(struct, field, translation)
       end
     end)
+  end
+
+  defp translate_fields(%{__struct__: module} = struct, locale, default_locale) do
+    translate_fields(struct, [locale], default_locale)
   end
 
   defp translate_assocs(%{__struct__: module} = struct, locale) do

--- a/test/trans/translator_test.exs
+++ b/test/trans/translator_test.exs
@@ -44,6 +44,12 @@ defmodule Trans.TranslatorTest do
 
       assert translated.content == struct.content
     end
+
+    test "falls back to the default locale if translation does not exist", %{struct: struct} do
+      translated = Translator.translate(struct, :fr)
+
+      assert translated.content == struct.content
+    end
   end
 
   describe inspect(&Translator.translate/3) do


### PR DESCRIPTION
The added test currently fails, but should work IMO. When the desired translation is missing the translatable field is `nil`:

```
  1) test &Trans.Translator.translate/2 falls back to the default locale if translation does not exist (Trans.TranslatorTest)
     test/trans/translator_test.exs:48
     Assertion with == failed
     code:  assert translated.content == struct.content
     left:  nil
     right: "Content EN"
     stacktrace:
       test/trans/translator_test.exs:51: (test)
 ```

