### PR TITLE
Publish release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# 3.0.1 - 2024-07-07 (requires Elixir 1.11 or newer)
+
+- Fall back to default locale when translation is missing
+
 # 3.0.0 - 2023-07-03 (requires Elixir 1.11 or newer)
 
 - Remove support for unstructured translations

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Trans.Mixfile do
   use Mix.Project
 
-  @version "3.0.0"
+  @version "3.0.1"
 
   def project do
     [


### PR DESCRIPTION
This release fixes a bug so `Translation.translate/2` falls back to the default locale when a translation is missing.